### PR TITLE
using LC_ALL=C instead of UTF-8 for latest stage3-*-CONTENTS.actual

### DIFF
--- a/mkroot
+++ b/mkroot
@@ -137,7 +137,7 @@ sed '/^# WHIRLPOOL HASH$/{N; s/.*/\n/}' ${LIVECD}/mirror/stage3/${stage3file}.DI
 
 if tar --version | grep -q '(GNU tar)'; then
     sinfo "Verifying stage3 files list"
-    LC_ALL=en_US.UTF-8 tar --utc -tjvf ${LIVECD}/mirror/stage3/${stage3file} > ${LIVECD}/mirror/stage3/${stage3file}.CONTENTS.actual
+    LC_ALL=C --utc -tjvf ${LIVECD}/mirror/stage3/${stage3file} > ${LIVECD}/mirror/stage3/${stage3file}.CONTENTS.actual
     cmp -s ${LIVECD}/mirror/stage3/${stage3file}.CONTENTS \
            ${LIVECD}/mirror/stage3/${stage3file}.CONTENTS.actual
     rm     ${LIVECD}/mirror/stage3/${stage3file}.CONTENTS.actual


### PR DESCRIPTION
The latest stage3-i686-20130528.tar.bz2.CONTENTS is using C locale instead of UTF-8, therefore some chars are octal encoded, e.g. \304\237.
